### PR TITLE
#86 Define Dogu V3 documentation structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ It has 3 main topics:
   - [interesting aspects](docs/additional/interesting_aspects_en.md)
   - [internal aspects](docs/additional/internal_aspects_en.md)
 
+## Dogu V3
+
+The Dogu V3 documentation is being developed. The current skeleton defines its navigation and content boundaries. Technical content will be added once the necessary V3 foundations are defined.
+
+- [Dogu V3 documentation — English](docs/v3/README.md)
+- [Dogu-V3-Dokumentation — Deutsch](docs/v3/README_de.md)
+
 ---
 
 ### What is the Cloudogu EcoSystem?

--- a/docs/additional/internal_aspects_de.md
+++ b/docs/additional/internal_aspects_de.md
@@ -138,7 +138,7 @@ stage('Trivy scan') {
 }
 ```
 
-[trivy]: https://github.com/cloudogu/dogu-build-lib/blob/develop/docs/development/trivy_de.md
+[trivy]: https://github.com/cloudogu/ces-build-lib/blob/main/README.md#scan-dogu-image-with-trivy
 
 #### Manuelle Tests auf einer Test-Stage
 
@@ -313,4 +313,3 @@ Dort können dann die Bilder abgelegt werden.
 | SCM-Manager     | SCM-Manager                       | Mit Bindestrich                      |
 | User Management | User Management                   | Nicht zusammengeschrieben            |
 | Warp Menü       | Warp Menü (de) und Warp Menu (en) | Das CES Ausklappmenü am rechten Rand |
-

--- a/docs/additional/internal_aspects_en.md
+++ b/docs/additional/internal_aspects_en.md
@@ -133,7 +133,7 @@ stage('Trivy scan') {
 }
 ```
 
-[trivy]: https://github.com/cloudogu/dogu-build-lib/blob/develop/docs/development/trivy_de.md
+[trivy]: https://github.com/cloudogu/ces-build-lib/blob/main/README.md#scan-dogu-image-with-trivy
 
 #### Manual testing on a test stage
 

--- a/docs/important/relevant_functionalities_de.md
+++ b/docs/important/relevant_functionalities_de.md
@@ -15,7 +15,7 @@ Grundlage für CAS ist hier immer eine korrekte Konfiguration eines Benutzer-/Gr
 
 ### CAS-Protokoll
 
-Authentifizierung innerhalb des Cloudogu EcoSystem geschieht über das [CAS-Protokoll](https://apereo.github.io/cas/7.0.x/protocol/CAS-Protocol.html), das Single Sign-on und Single Log-out ermöglicht. Es werden unterschiedliche CAS-Protokoll-Versionen unterstützt (2.0 und 3.0). Bei einer Umsetzung mittels CAS-Protokoll wird empfohlen, die Version 3.0 zu verwenden, da (verglichen mit Version 2.0) nach einer erfolgreichen Authentifizierung wichtige Benutzerattribute zurückgeliefert werden.
+Authentifizierung innerhalb des Cloudogu EcoSystem geschieht über das [CAS-Protokoll](https://apereo.github.io/cas/7.3.x/protocol/CAS-Protocol.html), das Single Sign-on und Single Log-out ermöglicht. Es werden unterschiedliche CAS-Protokoll-Versionen unterstützt (2.0 und 3.0). Bei einer Umsetzung mittels CAS-Protokoll wird empfohlen, die Version 3.0 zu verwenden, da (verglichen mit Version 2.0) nach einer erfolgreichen Authentifizierung wichtige Benutzerattribute zurückgeliefert werden.
 
 Folgendes Diagramm zeigt die Beteiligten an der Authentifizierungskonfiguration. Bevor ein Dogu (hier am Beispiel von Redmine) an diesem Prozess teilnehmen kann, muss das Dogu intern einen Satz von CAS-URLs konfigurieren:
 
@@ -34,7 +34,7 @@ Eine grobe Übersicht über den Anmeldeprozess mit den Beteiligten bietet die fo
 
 Das SSO des CAS reduziert diesen Prozess bei der Anmeldung bei weiteren Dogus deutlich.
 
-Weitere Informationen und eine genauere Abbildung vor, während und nach einer Authentifizierung bietet die [CAS-Dokumentation](https://apereo.github.io/cas/7.0.x/protocol/CAS-Protocol.html).
+Weitere Informationen und eine genauere Abbildung vor, während und nach einer Authentifizierung bietet die [CAS-Dokumentation](https://apereo.github.io/cas/7.3.x/protocol/CAS-Protocol.html).
 
 **Eintrag für einen normalen CAS Client:**
 

--- a/docs/important/relevant_functionalities_en.md
+++ b/docs/important/relevant_functionalities_en.md
@@ -16,7 +16,7 @@ The basis for CAS is always a correct configuration of a user/group directory, b
 
 ### CAS protocol
 
-Authentication within the Cloudogu EcoSystem is done using the [CAS protocol](https://apereo.github.io/cas/7.0.x/protocol/CAS-Protocol.html), which enables single sign-on and single log-out. Different CAS protocol versions are supported (2.0 and 3.0). When implementing using CAS protocol, it is recommended to use version 3.0 because (compared to version 2.0) it can return important user attributes after a successful authentication.
+Authentication within the Cloudogu EcoSystem is done using the [CAS protocol](https://apereo.github.io/cas/7.3.x/protocol/CAS-Protocol.html), which enables single sign-on and single log-out. Different CAS protocol versions are supported (2.0 and 3.0). When implementing using CAS protocol, it is recommended to use version 3.0 because (compared to version 2.0) it can return important user attributes after a successful authentication.
 
 The following diagram shows the parties involved in the authentication configuration. Before a dogu (here using Redmine as an example) can participate in this process, the dogu must internally configure a set of CAS URLs:
 
@@ -37,7 +37,7 @@ The following figure provides a rough overview of the login process with the par
 The SSO of the CAS significantly reduces this process when logging in to additional dogus.
 
 For more information and a more detailed illustration before, during and after an authentication, see
-the [CAS documentation](https://apereo.github.io/cas/7.0.x/protocol/CAS-Protocol.html).
+the [CAS documentation](https://apereo.github.io/cas/7.3.x/protocol/CAS-Protocol.html).
 
 **entry for a normal CAS client:**
 

--- a/docs/v3/README.md
+++ b/docs/v3/README.md
@@ -2,8 +2,6 @@
 
 This area will guide Dogu developers through developing and operating Dogu V3 applications.
 
-> **Documentation status:** The documentation structure is available, but the technical documentation is not yet complete. Topic pages will be added once the necessary V3 foundations are defined.
-
 ## Planned learning path
 
 The documentation will guide developers from a minimal working Dogu to more detailed, task-oriented information:
@@ -15,23 +13,7 @@ The documentation will guide developers from a minimal working Dogu to more deta
 5. add CES integrations in focused guides; and
 6. consult release, migration, or troubleshooting information when needed.
 
-## Target structure
-
-The following tree is the target structure. Directories and pages are created by the follow-up stories that provide their actual content; they are not created as empty placeholders.
-
-```text
-docs/v3/
-├── README.md / README_de.md
-├── getting-started/   # prerequisites, quick start, and advanced guide
-├── concepts/          # Dogu V3, artifacts, lifecycle, and Multinode context
-├── guides/            # task-oriented integration, release, and migration guides
-├── reference/         # artifact overview and links to normative contracts
-├── best-practices/    # CES-specific chart, image, and security practices
-├── troubleshooting/   # symptom-oriented diagnostics
-└── images/            # editable diagram sources and rendered images
-```
-
-### Content boundaries
+## Content boundaries
 
 - **Getting started** contains executable end-to-end instructions. The quick start covers only the smallest working happy path.
 - **Concepts** explain the mental model and relationships without duplicating technical references.

--- a/docs/v3/README.md
+++ b/docs/v3/README.md
@@ -1,0 +1,46 @@
+# Dogu V3 Documentation
+
+This area will guide Dogu developers through developing and operating Dogu V3 applications.
+
+> **Documentation status:** The documentation structure is available, but the technical documentation is not yet complete. Topic pages will be added once the necessary V3 foundations are defined.
+
+## Planned learning path
+
+The documentation will guide developers from a minimal working Dogu to more detailed, task-oriented information:
+
+1. prepare the local development environment;
+2. deploy a minimal Dogu V3 with a quick start;
+3. understand the artifacts and lifecycle;
+4. understand the relevant Multinode environment;
+5. add CES integrations in focused guides; and
+6. consult release, migration, or troubleshooting information when needed.
+
+## Target structure
+
+The following tree is the target structure. Directories and pages are created by the follow-up stories that provide their actual content; they are not created as empty placeholders.
+
+```text
+docs/v3/
+├── README.md / README_de.md
+├── getting-started/   # prerequisites, quick start, and advanced guide
+├── concepts/          # Dogu V3, artifacts, lifecycle, and Multinode context
+├── guides/            # task-oriented integration, release, and migration guides
+├── reference/         # artifact overview and links to normative contracts
+├── best-practices/    # CES-specific chart, image, and security practices
+├── troubleshooting/   # symptom-oriented diagnostics
+└── images/            # editable diagram sources and rendered images
+```
+
+### Content boundaries
+
+- **Getting started** contains executable end-to-end instructions. The quick start covers only the smallest working happy path.
+- **Concepts** explain the mental model and relationships without duplicating technical references.
+- **Guides** explain how to complete a specific Dogu development task.
+- **Reference** provides compact lookup information and links to the owning repositories for complete API contracts.
+- **Best practices** contain only Cloudogu- and CES-specific guidance. General Helm, Kubernetes, OCI, and container documentation is linked instead of rewritten.
+- **Troubleshooting** starts from observable symptoms and links to component-specific diagnostics where appropriate.
+
+## Boundary to Dogu V2
+
+- All existing pages in `docs/core`, `docs/important`, and `docs/additional` describe Dogu V2 unless a page explicitly states otherwise.
+- Native Dogu V3 behavior is documented only below `docs/v3`.

--- a/docs/v3/README_de.md
+++ b/docs/v3/README_de.md
@@ -1,0 +1,46 @@
+# Dogu-V3-Dokumentation
+
+Dieser Bereich wird Dogu-Entwickler:innen durch die Entwicklung und den Betrieb von Dogu-V3-Anwendungen führen.
+
+> **Dokumentationsstatus:** Die Dokumentationsstruktur ist vorhanden, die technische Dokumentation aber noch nicht vollständig. Themenseiten werden ergänzt, sobald die nötigen V3-Grundlagen feststehen.
+
+## Geplanter Lernpfad
+
+Die Dokumentation wird Entwickler:innen von einem minimalen lauffähigen Dogu zu detaillierten, aufgabenorientierten Informationen führen:
+
+1. die lokale Entwicklungsumgebung vorbereiten,
+2. mit einem Quickstart ein minimales Dogu V3 bereitstellen,
+3. Artefakte und Lebenszyklus verstehen,
+4. die relevante Multinode-Umgebung verstehen,
+5. CES-Integrationen mit gezielten Anleitungen ergänzen und
+6. bei Bedarf Informationen zu Release, Migration oder Fehlerbehebung nachschlagen.
+
+## Zielstruktur
+
+Der folgende Baum ist die Zielstruktur. Verzeichnisse und Seiten werden erst durch die Folge-Storys angelegt, die ihre tatsächlichen Inhalte liefern; leere Platzhalter werden nicht erstellt.
+
+```text
+docs/v3/
+├── README_en.md / README_de.md
+├── getting-started/   # Voraussetzungen, Quickstart und erweiterte Anleitung
+├── concepts/          # Dogu V3, Artefakte, Lebenszyklus und Multinode-Kontext
+├── guides/            # Aufgabenorientierte Integrations-, Release- und Migrationsanleitungen
+├── reference/         # Artefaktübersicht und Links auf normative Verträge
+├── best-practices/    # CES-spezifische Chart-, Image- und Sicherheitspraktiken
+├── troubleshooting/   # Symptomorientierte Diagnose
+└── images/            # Editierbare Diagrammquellen und gerenderte Bilder
+```
+
+### Inhaltliche Abgrenzung
+
+- **Erste Schritte** enthalten ausführbare, durchgängige Anleitungen. Der Quickstart behandelt nur den kleinsten lauffähigen Happy Path.
+- **Konzepte** erklären das mentale Modell und Zusammenhänge, ohne technische Referenzen zu duplizieren.
+- **Anleitungen** erklären, wie eine konkrete Aufgabe der Dogu-Entwicklung erledigt wird.
+- **Referenz** bietet kompakte Informationen zum Nachschlagen und verlinkt für vollständige API-Verträge auf die verantwortlichen Repositories.
+- **Best Practices** enthalten nur Cloudogu- und CES-spezifische Hinweise. Allgemeine Helm-, Kubernetes-, OCI- und Container-Dokumentation wird verlinkt statt neu geschrieben.
+- **Fehlerbehebung** beginnt bei beobachtbaren Symptomen und verlinkt bei Bedarf auf komponentenspezifische Diagnosen.
+
+## Abgrenzung zu Dogu V2
+
+- Alle bestehenden Seiten in `docs/core`, `docs/important` und `docs/additional` beschreiben Dogu V2, sofern eine Seite nicht ausdrücklich etwas anderes angibt.
+- Natives Dogu-V3-Verhalten wird ausschließlich unterhalb von `docs/v3` dokumentiert.

--- a/docs/v3/README_de.md
+++ b/docs/v3/README_de.md
@@ -2,8 +2,6 @@
 
 Dieser Bereich wird Dogu-Entwickler:innen durch die Entwicklung und den Betrieb von Dogu-V3-Anwendungen führen.
 
-> **Dokumentationsstatus:** Die Dokumentationsstruktur ist vorhanden, die technische Dokumentation aber noch nicht vollständig. Themenseiten werden ergänzt, sobald die nötigen V3-Grundlagen feststehen.
-
 ## Geplanter Lernpfad
 
 Die Dokumentation wird Entwickler:innen von einem minimalen lauffähigen Dogu zu detaillierten, aufgabenorientierten Informationen führen:
@@ -15,23 +13,7 @@ Die Dokumentation wird Entwickler:innen von einem minimalen lauffähigen Dogu zu
 5. CES-Integrationen mit gezielten Anleitungen ergänzen und
 6. bei Bedarf Informationen zu Release, Migration oder Fehlerbehebung nachschlagen.
 
-## Zielstruktur
-
-Der folgende Baum ist die Zielstruktur. Verzeichnisse und Seiten werden erst durch die Folge-Storys angelegt, die ihre tatsächlichen Inhalte liefern; leere Platzhalter werden nicht erstellt.
-
-```text
-docs/v3/
-├── README_en.md / README_de.md
-├── getting-started/   # Voraussetzungen, Quickstart und erweiterte Anleitung
-├── concepts/          # Dogu V3, Artefakte, Lebenszyklus und Multinode-Kontext
-├── guides/            # Aufgabenorientierte Integrations-, Release- und Migrationsanleitungen
-├── reference/         # Artefaktübersicht und Links auf normative Verträge
-├── best-practices/    # CES-spezifische Chart-, Image- und Sicherheitspraktiken
-├── troubleshooting/   # Symptomorientierte Diagnose
-└── images/            # Editierbare Diagrammquellen und gerenderte Bilder
-```
-
-### Inhaltliche Abgrenzung
+## Inhaltliche Abgrenzung
 
 - **Erste Schritte** enthalten ausführbare, durchgängige Anleitungen. Der Quickstart behandelt nur den kleinsten lauffähigen Happy Path.
 - **Konzepte** erklären das mentale Modell und Zusammenhänge, ohne technische Referenzen zu duplizieren.


### PR DESCRIPTION
Created the minimal base structure for the future Dogu V3 documentation:

- Added docs/v3/README.md as the automatically rendered English entry page.
- Added docs/v3/README_de.md as the German entry page.
- Updated the root README.md with explicit V2/V3 navigation.
- Documented the planned V3 directory structure and content boundaries in the entry pages.
- Deliberately avoided empty directories and placeholder files; follow-up stories will create them together with real content.
- Existing Dogu V2 files and paths remain unchanged.

Closes https://github.com/cloudogu/dogu-development-docs/issues/86